### PR TITLE
Capture stderr in docker log waits

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Harbor"
 uuid = "af79dbb9-1a80-47ad-8928-192a4af69376"
-version = "1.0.2"
+version = "1.0.3"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/src/docker.jl
+++ b/src/docker.jl
@@ -165,7 +165,9 @@ function docker_logs(container_id::String; follow::Bool=false, tail::Union{Strin
     push!(args, "--tail=" * string(tail))
     push!(args, container_id)
     cmd = Cmd(vcat(["docker", "logs"], args))
-    return read(cmd, String)
+    output = PipeBuffer()
+    run(pipeline(cmd; stdout=output, stderr=output))
+    return String(take!(output))
 end
 
 """

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -23,7 +23,7 @@ using Test, Harbor
     @testset "remove image" begin
         # We pull a temporary image for removal.
         tmp_img = Harbor.pull("alpine"; tag="latest")
-        removal_result = Harbor.remove(tmp_img; force=false)
+        removal_result = Harbor.remove(tmp_img; force=true)
         @test removal_result == true
     end
 
@@ -80,6 +80,21 @@ using Test, Harbor
         result = Harbor.with_container("alpine"; command=["sleep", "1"]) do cont
             @test cont.status == :running
             # Return a simple result.
+            "done"
+        end
+        @test result == "done"
+    end
+
+    @testset "log wait captures stderr" begin
+        result = Harbor.with_container(
+            "alpine";
+            command=["sh", "-c", "echo stdout-ready; echo stderr-ready >&2; sleep 1"],
+            wait_strategy=(pattern="stderr-ready",),
+            wait_timeout=5.0,
+        ) do cont
+            logs_output = Harbor.logs(cont; follow=false, tail="all")
+            @test occursin("stdout-ready", logs_output)
+            @test occursin("stderr-ready", logs_output)
             "done"
         end
         @test result == "done"


### PR DESCRIPTION
## Summary
- merge stdout and stderr when collecting `docker logs` so log-pattern wait strategies can match stderr output
- add a regression test that waits on a stderr-only pattern and verifies both streams are returned from `Harbor.logs`
- bump Harbor to `1.0.3`

## Verification
- `julia --project=. -e 'using Pkg; Pkg.test(; coverage=false)'`
- direct `mysql:8` repro now finds `ready for connections` via log-pattern waiting
